### PR TITLE
Update dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
       <plugin>
         <groupId>co.cask</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <configuration>
           <cdapArtifacts>
             <parent>system:cdap-data-pipeline[4.0.0,5.0.0-SNAPSHOT)</parent>


### PR DESCRIPTION
Build breaks as-is because of missing SNAPSHOT version of a dependency. WIth the correct release version, the build succeeds